### PR TITLE
Themes

### DIFF
--- a/app/javascript/styles/arcdark.scss
+++ b/app/javascript/styles/arcdark.scss
@@ -1,6 +1,7 @@
 $ui-base-color: #383c4a;
 $ui-secondary-color: #7c818c;
 $ui-primary-color: $ui-secondary-color;
+$ui-secondary-color: #CC575D;
 $ui-highlight-color: #5294e2;
 $ui-card-secondary-color: lighten($ui-base-color, 30%);
 $gold-star: $ui-highlight-color;

--- a/app/javascript/styles/arcdark.scss
+++ b/app/javascript/styles/arcdark.scss
@@ -3,7 +3,7 @@ $ui-secondary-color: #7c818c;
 $ui-primary-color: $ui-secondary-color;
 $ui-secondary-color: #CC575D;
 $ui-highlight-color: #5294e2;
-$ui-card-secondary-color: lighten($ui-base-color, 30%);
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
 $gold-star: $ui-highlight-color;
 
 @import 'application';

--- a/app/javascript/styles/arcdark.scss
+++ b/app/javascript/styles/arcdark.scss
@@ -1,0 +1,8 @@
+$ui-base-color: #383c4a;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: $ui-secondary-color;
+$ui-highlight-color: #5294e2;
+$ui-card-secondary-color: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;
+
+@import 'application';

--- a/app/javascript/styles/darkest.scss
+++ b/app/javascript/styles/darkest.scss
@@ -1,0 +1,9 @@
+$ui-base-color: #111111;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: #EBDC98;
+$ui-secondary-color: #EBDC98;
+$ui-highlight-color: #CC575D;
+$ui-card-secondary-color: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;
+
+@import 'application';

--- a/app/javascript/styles/darkest.scss
+++ b/app/javascript/styles/darkest.scss
@@ -3,7 +3,7 @@ $ui-secondary-color: #7c818c;
 $ui-primary-color: #EBDC98;
 $ui-secondary-color: #EBDC98;
 $ui-highlight-color: #CC575D;
-$ui-card-secondary-color: lighten($ui-base-color, 30%);
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
 $gold-star: $ui-highlight-color;
 
 @import 'application';

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -514,7 +514,7 @@
 
 .activity-stream-tabs {
   background: $simple-background-color;
-  border-bottom: 1px solid $ui-secondary-color;
+  border-bottom: 1px solid $ui-card-secondary-color;
   position: relative;
   z-index: 2;
 

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -514,7 +514,7 @@
 
 .activity-stream-tabs {
   background: $simple-background-color;
-  border-bottom: 1px solid $ui-card-secondary-color;
+  border-bottom: 1px solid $ui-simple-bg-contrast;
   position: relative;
   z-index: 2;
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -524,7 +524,7 @@
 
   .compose-form__buttons-wrapper {
     padding: 10px;
-    background: darken($simple-background-color, 8%);
+    background: $ui-base-color;
     border-radius: 0 0 4px 4px;
     display: flex;
     justify-content: space-between;
@@ -563,7 +563,7 @@
         font-family: 'mastodon-font-sans-serif', sans-serif;
         font-size: 14px;
         font-weight: 600;
-        color: lighten($ui-base-color, 12%);
+        color: lighten($ui-primary-color, 33%);
 
         &.character-counter--over {
           color: $warning-red;
@@ -4767,12 +4767,12 @@ a.status-card {
   padding: 10px 14px;
   padding-bottom: 14px;
   margin-top: 10px;
-  color: $ui-primary-color;
+  color: $ui-card-secondary-color;
   box-shadow: 2px 4px 15px rgba($base-shadow-color, 0.4);
 
   h4 {
     text-transform: uppercase;
-    color: $ui-primary-color;
+    color: $ui-card-secondary-color;
     font-size: 13px;
     font-weight: 500;
     margin-bottom: 10px;

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -1579,7 +1579,7 @@
     &:focus,
     &:hover,
     &:active {
-      background: $ui-highlight-color;
+      background: darken($ui-secondary-color, 20%);
       color: $ui-secondary-color;
       outline: 0;
     }

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -4767,12 +4767,12 @@ a.status-card {
   padding: 10px 14px;
   padding-bottom: 14px;
   margin-top: 10px;
-  color: $ui-card-secondary-color;
+  color: $ui-simple-bg-contrast;
   box-shadow: 2px 4px 15px rgba($base-shadow-color, 0.4);
 
   h4 {
     text-transform: uppercase;
-    color: $ui-card-secondary-color;
+    color: $ui-simple-bg-contrast;
     font-size: 13px;
     font-weight: 500;
     margin-bottom: 10px;

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -36,7 +36,7 @@
   display: flex;
   justify-content: space-between;
   padding: 0 6px;
-  color: $ui-primary-color;
+  color: $ui-card-secondary-color;
   line-height: 0;
 }
 

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -36,7 +36,7 @@
   display: flex;
   justify-content: space-between;
   padding: 0 6px;
-  color: $ui-card-secondary-color;
+  color: $ui-simple-bg-contrast;
   line-height: 0;
 }
 

--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -7,7 +7,7 @@
 
     .detailed-status.light,
     .status.light {
-      border-bottom: 1px solid $ui-secondary-color;
+      border-bottom: 1px solid $ui-card-secondary-color;
       animation: none;
     }
 
@@ -83,7 +83,8 @@
         font-size: 14px;
 
         .status__relative-time {
-          color: $ui-primary-color;
+          color: $ui-card-secondary-color;
+          font-weight: bold;
         }
       }
     }
@@ -133,7 +134,7 @@
 
       span {
         font-size: 14px;
-        color: $ui-primary-color;
+        color: $ui-card-secondary-color;
       }
     }
 
@@ -190,7 +191,7 @@
 
         span {
           font-size: 14px;
-          color: $ui-primary-color;
+          color: $ui-card-secondary-color;
         }
       }
     }
@@ -224,7 +225,7 @@
 
     .detailed-status__meta {
       margin-top: 15px;
-      color: $ui-primary-color;
+      color: $ui-card-secondary-color;
       font-size: 14px;
       line-height: 18px;
 

--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -7,7 +7,7 @@
 
     .detailed-status.light,
     .status.light {
-      border-bottom: 1px solid $ui-card-secondary-color;
+      border-bottom: 1px solid $ui-simple-bg-contrast;
       animation: none;
     }
 
@@ -83,7 +83,7 @@
         font-size: 14px;
 
         .status__relative-time {
-          color: $ui-card-secondary-color;
+          color: $ui-simple-bg-contrast;
           font-weight: bold;
         }
       }
@@ -134,7 +134,7 @@
 
       span {
         font-size: 14px;
-        color: $ui-card-secondary-color;
+        color: $ui-simple-bg-contrast;
       }
     }
 
@@ -191,7 +191,7 @@
 
         span {
           font-size: 14px;
-          color: $ui-card-secondary-color;
+          color: $ui-simple-bg-contrast;
         }
       }
     }
@@ -225,7 +225,7 @@
 
     .detailed-status__meta {
       margin-top: 15px;
-      color: $ui-card-secondary-color;
+      color: $ui-simple-bg-contrast;
       font-size: 14px;
       line-height: 18px;
 

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -27,7 +27,7 @@ $ui-base-lighter-color: lighten($ui-base-color, 26%) !default; // Lighter darkes
 $ui-primary-color: $classic-primary-color !default;            // Lighter
 $ui-secondary-color: $classic-secondary-color !default;        // Lightest
 $ui-highlight-color: $classic-highlight-color !default;        // Vibrant
-$ui-card-secondary-color: $ui-primary-color !default;
+$ui-simple-bg-contrast: $ui-primary-color !default;            // Contrast color for elements too bright for $simple-background-color
 
 // Language codes that uses CJK fonts
 $cjk-langs: ja, ko, zh-CN, zh-HK, zh-TW;

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -27,6 +27,7 @@ $ui-base-lighter-color: lighten($ui-base-color, 26%) !default; // Lighter darkes
 $ui-primary-color: $classic-primary-color !default;            // Lighter
 $ui-secondary-color: $classic-secondary-color !default;        // Lightest
 $ui-highlight-color: $classic-highlight-color !default;        // Vibrant
+$ui-card-secondary-color: $ui-primary-color !default;
 
 // Language codes that uses CJK fonts
 $cjk-langs: ja, ko, zh-CN, zh-HK, zh-TW;

--- a/app/javascript/styles/solarizeddark.scss
+++ b/app/javascript/styles/solarizeddark.scss
@@ -1,0 +1,14 @@
+// Turn your face to the sun and the shadows will fall behind you.
+
+$primary-text-color: lighten(#93A1A1, 25%);
+
+$ui-base-color: #002B36;
+$ui-base-lighter-color: lighten($ui-base-color, 30%);
+$ui-primary-color: #93A1A1;
+$ui-secondary-color: #2AA198;
+$ui-highlight-color: #6C71C4;
+$ui-card-secondary-color: #6C71C4;
+
+$gold-star: #CB4B16;
+
+@import 'application';

--- a/app/javascript/styles/solarizeddark.scss
+++ b/app/javascript/styles/solarizeddark.scss
@@ -7,7 +7,7 @@ $ui-base-lighter-color: lighten($ui-base-color, 30%);
 $ui-primary-color: #93A1A1;
 $ui-secondary-color: #2AA198;
 $ui-highlight-color: #6C71C4;
-$ui-card-secondary-color: #6C71C4;
+$ui-simple-bg-contrast: #6C71C4;
 
 $gold-star: #CB4B16;
 

--- a/app/javascript/styles/technology.scss
+++ b/app/javascript/styles/technology.scss
@@ -4,6 +4,7 @@ $ui-primary-color: #EBDC98;
 $ui-highlight-color: #398CCC;
 $error-value-color: #FF003C;
 $valid-value-color: #A8BF34;
+$ui-card-secondary-color: lighten($ui-base-color, 30%);
 $gold-star: #EBDC98;
 
 @import 'application';

--- a/app/javascript/styles/technology.scss
+++ b/app/javascript/styles/technology.scss
@@ -4,7 +4,7 @@ $ui-primary-color: #EBDC98;
 $ui-highlight-color: #398CCC;
 $error-value-color: #FF003C;
 $valid-value-color: #A8BF34;
-$ui-card-secondary-color: lighten($ui-base-color, 30%);
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
 $gold-star: #EBDC98;
 
 @import 'application';

--- a/app/javascript/styles/woolly.scss
+++ b/app/javascript/styles/woolly.scss
@@ -1,0 +1,9 @@
+$ui-base-color: #392613;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: #EBDC98;
+$ui-secondary-color: #EBDC98;
+$ui-highlight-color: #9494b8;
+$ui-card-secondary-color: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;
+
+@import 'application';

--- a/app/javascript/styles/woolly.scss
+++ b/app/javascript/styles/woolly.scss
@@ -3,7 +3,7 @@ $ui-secondary-color: #7c818c;
 $ui-primary-color: #EBDC98;
 $ui-secondary-color: #EBDC98;
 $ui-highlight-color: #9494b8;
-$ui-card-secondary-color: lighten($ui-base-color, 30%);
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
 $gold-star: $ui-highlight-color;
 
 @import 'application';

--- a/config/themes.yml
+++ b/config/themes.yml
@@ -3,3 +3,4 @@ ArcDark: styles/arcdark.scss
 Darkest: styles/darkest.scss
 Eugen: styles/application.scss
 SolarizedDark: styles/solarizeddark.scss
+Woolly: styles/woolly.scss

--- a/config/themes.yml
+++ b/config/themes.yml
@@ -1,3 +1,4 @@
 default: styles/technology.scss
-Eugen: styles/application.scss
 ArcDark: styles/arcdark.scss
+Eugen: styles/application.scss
+SolarizedDark: styles/solarizeddark.scss

--- a/config/themes.yml
+++ b/config/themes.yml
@@ -1,1 +1,3 @@
-default: styles/custom.scss
+default: styles/technology.scss
+Eugen: styles/application.scss
+ArcDark: styles/arcdark.scss

--- a/config/themes.yml
+++ b/config/themes.yml
@@ -1,4 +1,5 @@
 default: styles/technology.scss
 ArcDark: styles/arcdark.scss
+Darkest: styles/darkest.scss
 Eugen: styles/application.scss
 SolarizedDark: styles/solarizeddark.scss


### PR DESCRIPTION
Hey Ash. It's Trev (@trevdev@mastodon.technology).

Here's my themes branch of your instance. It fixes the yellow text on the white background and adds 1 new theme (ArcDark). It also unlocks the default mastodon theme as its own theme (Eugen). I would love to add more themes! Let me know if you have any requests or objections.

Things I did that weren't obvious in the commit message:
a0c8983 Add a variable to handle contrast issues on white backgrounds
64010dc Re-setup existing themes in config file to allow switching between them. Add ArcDark
6cda562 Apply new contrast variable to emoji menu category buttons. This way, it's easier to control whether or not they blend in with the background too easily.
34f63c6 Adjusted variables in components.scss to enable the ability to avoid contrast issues using new contrast variable.
16fd378 Add red as the highlight color for ArcDark
a53c77a Make the highlight color for the user hamburger menu dropdown items a darker version of the bg color. This way we don't end up with horrible contrasts like red on green, purple on teal, etc.





Edit: 4 new themes added in addition to @ashfurrow's custom theme and the default Mastodon theme.
_Arc Dark_
![arkdark](https://user-images.githubusercontent.com/28788713/38783041-a71c2518-40b1-11e8-8316-3edd3e170d4b.png)
_Darkest_
![darkest](https://user-images.githubusercontent.com/28788713/38783042-adbf9756-40b1-11e8-8327-1b390c32d239.png)
_Solarized Dark_
![solarizeddark](https://user-images.githubusercontent.com/28788713/38783044-b9e153f8-40b1-11e8-89d4-8d4375ffb396.png)
_Woolly_
![woolly](https://user-images.githubusercontent.com/28788713/38783047-c0817bde-40b1-11e8-939b-65ef7fb4f5fa.png)
