### PR TITLE
Themes refactor

### DIFF
--- a/app/javascript/styles/arcdark.scss
+++ b/app/javascript/styles/arcdark.scss
@@ -1,9 +1,3 @@
-$ui-base-color: #383c4a;
-$ui-secondary-color: #7c818c;
-$ui-primary-color: $ui-secondary-color;
-$ui-secondary-color: #CC575D;
-$ui-highlight-color: #5294e2;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: $ui-highlight-color;
-
+@import './arcdark/variables';
 @import 'application';
+@import './arcdark/diff';

--- a/app/javascript/styles/arcdark.scss
+++ b/app/javascript/styles/arcdark.scss
@@ -1,3 +1,3 @@
-@import './arcdark/variables';
 @import 'application';
+@import './arcdark/variables';
 @import './arcdark/diff';

--- a/app/javascript/styles/arcdark/diff.scss
+++ b/app/javascript/styles/arcdark/diff.scss
@@ -1,0 +1,75 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  border-bottom: 1px solid $ui-simple-bg-contrast;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+    a {
+      &:focus,
+      &:hover,
+      &:active {
+        background: darken($ui-secondary-color, 20%);
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+
+.activity-stream {
+  .entry {
+    .detailed-status.light,
+    .status.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+    .status.light {
+      .status__header {
+        .status__meta {
+          .status__relative-time {
+            color: $ui-simple-bg-contrast;
+            font-weight: bold;
+          }
+        }
+      }
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+    .detailed-status.light {
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+      .detailed-status__meta {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }  
+}

--- a/app/javascript/styles/arcdark/variables.scss
+++ b/app/javascript/styles/arcdark/variables.scss
@@ -1,4 +1,5 @@
-$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-simple-bg-contrast: $ui-primary-color;
+
 $ui-base-color: #383c4a;
 $ui-secondary-color: #7c818c;
 $ui-primary-color: $ui-secondary-color;

--- a/app/javascript/styles/arcdark/variables.scss
+++ b/app/javascript/styles/arcdark/variables.scss
@@ -1,0 +1,8 @@
+$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-base-color: #383c4a;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: $ui-secondary-color;
+$ui-secondary-color: #CC575D;
+$ui-highlight-color: #5294e2;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;

--- a/app/javascript/styles/darkest.scss
+++ b/app/javascript/styles/darkest.scss
@@ -1,9 +1,3 @@
-$ui-base-color: #111111;
-$ui-secondary-color: #7c818c;
-$ui-primary-color: #EBDC98;
-$ui-secondary-color: #EBDC98;
-$ui-highlight-color: #CC575D;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: $ui-highlight-color;
-
+@import './darkest/variables';
 @import 'application';
+@import './darkest/diff';

--- a/app/javascript/styles/darkest.scss
+++ b/app/javascript/styles/darkest.scss
@@ -1,3 +1,3 @@
-@import './darkest/variables';
 @import 'application';
+@import './darkest/variables';
 @import './darkest/diff';

--- a/app/javascript/styles/darkest/diff.scss
+++ b/app/javascript/styles/darkest/diff.scss
@@ -1,0 +1,75 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  border-bottom: 1px solid $ui-simple-bg-contrast;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+    a {
+      &:focus,
+      &:hover,
+      &:active {
+        background: darken($ui-secondary-color, 20%);
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+
+.activity-stream {
+  .entry {
+    .detailed-status.light,
+    .status.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+    .status.light {
+      .status__header {
+        .status__meta {
+          .status__relative-time {
+            color: $ui-simple-bg-contrast;
+            font-weight: bold;
+          }
+        }
+      }
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+    .detailed-status.light {
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+      .detailed-status__meta {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }  
+}

--- a/app/javascript/styles/darkest/variables.scss
+++ b/app/javascript/styles/darkest/variables.scss
@@ -1,4 +1,4 @@
-$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-simple-bg-contrast: $ui-primary-color;
 $ui-base-color: #111111;
 $ui-secondary-color: #7c818c;
 $ui-primary-color: #EBDC98;

--- a/app/javascript/styles/darkest/variables.scss
+++ b/app/javascript/styles/darkest/variables.scss
@@ -1,0 +1,8 @@
+$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-base-color: #111111;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: #EBDC98;
+$ui-secondary-color: #EBDC98;
+$ui-highlight-color: #CC575D;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -514,7 +514,7 @@
 
 .activity-stream-tabs {
   background: $simple-background-color;
-  border-bottom: 1px solid $ui-simple-bg-contrast;
+  border-bottom: 1px solid $ui-secondary-color;
   position: relative;
   z-index: 2;
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -524,7 +524,7 @@
 
   .compose-form__buttons-wrapper {
     padding: 10px;
-    background: $ui-base-color;
+    background: darken($simple-background-color, 8%);
     border-radius: 0 0 4px 4px;
     display: flex;
     justify-content: space-between;
@@ -563,7 +563,7 @@
         font-family: 'mastodon-font-sans-serif', sans-serif;
         font-size: 14px;
         font-weight: 600;
-        color: lighten($ui-primary-color, 33%);
+        color: lighten($ui-base-color, 12%);
 
         &.character-counter--over {
           color: $warning-red;
@@ -1579,7 +1579,7 @@
     &:focus,
     &:hover,
     &:active {
-      background: darken($ui-secondary-color, 20%);
+      background: $ui-highlight-color;
       color: $ui-secondary-color;
       outline: 0;
     }
@@ -4767,12 +4767,12 @@ a.status-card {
   padding: 10px 14px;
   padding-bottom: 14px;
   margin-top: 10px;
-  color: $ui-simple-bg-contrast;
+  color: $ui-primary-color;
   box-shadow: 2px 4px 15px rgba($base-shadow-color, 0.4);
 
   h4 {
     text-transform: uppercase;
-    color: $ui-simple-bg-contrast;
+    color: $ui-primary-color;
     font-size: 13px;
     font-weight: 500;
     margin-bottom: 10px;

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -36,7 +36,7 @@
   display: flex;
   justify-content: space-between;
   padding: 0 6px;
-  color: $ui-simple-bg-contrast;
+  color: $ui-primary-color;
   line-height: 0;
 }
 

--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -7,7 +7,7 @@
 
     .detailed-status.light,
     .status.light {
-      border-bottom: 1px solid $ui-simple-bg-contrast;
+      border-bottom: 1px solid $ui-secondary-color;
       animation: none;
     }
 
@@ -83,8 +83,7 @@
         font-size: 14px;
 
         .status__relative-time {
-          color: $ui-simple-bg-contrast;
-          font-weight: bold;
+          color: $ui-primary-color;
         }
       }
     }
@@ -134,7 +133,7 @@
 
       span {
         font-size: 14px;
-        color: $ui-simple-bg-contrast;
+        color: $ui-primary-color;
       }
     }
 
@@ -191,7 +190,7 @@
 
         span {
           font-size: 14px;
-          color: $ui-simple-bg-contrast;
+          color: $ui-primary-color;
         }
       }
     }
@@ -225,7 +224,7 @@
 
     .detailed-status__meta {
       margin-top: 15px;
-      color: $ui-simple-bg-contrast;
+      color: $ui-primary-color;
       font-size: 14px;
       line-height: 18px;
 

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -27,7 +27,6 @@ $ui-base-lighter-color: lighten($ui-base-color, 26%) !default; // Lighter darkes
 $ui-primary-color: $classic-primary-color !default;            // Lighter
 $ui-secondary-color: $classic-secondary-color !default;        // Lightest
 $ui-highlight-color: $classic-highlight-color !default;        // Vibrant
-$ui-simple-bg-contrast: $ui-primary-color !default;            // Contrast color for elements too bright for $simple-background-color
 
 // Language codes that uses CJK fonts
 $cjk-langs: ja, ko, zh-CN, zh-HK, zh-TW;

--- a/app/javascript/styles/solarizeddark.scss
+++ b/app/javascript/styles/solarizeddark.scss
@@ -1,14 +1,4 @@
 // Turn your face to the sun and the shadows will fall behind you.
-
-$primary-text-color: lighten(#93A1A1, 25%);
-
-$ui-base-color: #002B36;
-$ui-base-lighter-color: lighten($ui-base-color, 30%);
-$ui-primary-color: #93A1A1;
-$ui-secondary-color: #2AA198;
-$ui-highlight-color: #6C71C4;
-$ui-simple-bg-contrast: #6C71C4;
-
-$gold-star: #CB4B16;
-
+@import './solarizeddark/variables';
 @import 'application';
+@import './solarizeddark/diff';

--- a/app/javascript/styles/solarizeddark.scss
+++ b/app/javascript/styles/solarizeddark.scss
@@ -1,4 +1,4 @@
 // Turn your face to the sun and the shadows will fall behind you.
-@import './solarizeddark/variables';
 @import 'application';
+@import './solarizeddark/variables';
 @import './solarizeddark/diff';

--- a/app/javascript/styles/solarizeddark/diff.scss
+++ b/app/javascript/styles/solarizeddark/diff.scss
@@ -1,0 +1,75 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  border-bottom: 1px solid $ui-simple-bg-contrast;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+    a {
+      &:focus,
+      &:hover,
+      &:active {
+        background: darken($ui-secondary-color, 20%);
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+
+.activity-stream {
+  .entry {
+    .detailed-status.light,
+    .status.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+    .status.light {
+      .status__header {
+        .status__meta {
+          .status__relative-time {
+            color: $ui-simple-bg-contrast;
+            font-weight: bold;
+          }
+        }
+      }
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+    .detailed-status.light {
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+      .detailed-status__meta {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }  
+}

--- a/app/javascript/styles/solarizeddark/variables.scss
+++ b/app/javascript/styles/solarizeddark/variables.scss
@@ -1,0 +1,9 @@
+$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$primary-text-color: lighten(#93A1A1, 25%);
+$ui-base-color: #002B36;
+$ui-base-lighter-color: lighten($ui-base-color, 30%);
+$ui-primary-color: #93A1A1;
+$ui-secondary-color: #2AA198;
+$ui-highlight-color: #6C71C4;
+$ui-simple-bg-contrast: #6C71C4;
+$gold-star: #CB4B16;

--- a/app/javascript/styles/solarizeddark/variables.scss
+++ b/app/javascript/styles/solarizeddark/variables.scss
@@ -1,4 +1,5 @@
-$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-simple-bg-contrast: $ui-primary-color;
+
 $primary-text-color: lighten(#93A1A1, 25%);
 $ui-base-color: #002B36;
 $ui-base-lighter-color: lighten($ui-base-color, 30%);

--- a/app/javascript/styles/technology.scss
+++ b/app/javascript/styles/technology.scss
@@ -1,10 +1,3 @@
-$ui-base-color: #0E2333;
-$ui-secondary-color: #E4E6DA;
-$ui-primary-color: #EBDC98;
-$ui-highlight-color: #398CCC;
-$error-value-color: #FF003C;
-$valid-value-color: #A8BF34;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: #EBDC98;
-
+@import './technology/variables';
 @import 'application';
+@import './technology/diff';

--- a/app/javascript/styles/technology.scss
+++ b/app/javascript/styles/technology.scss
@@ -1,3 +1,3 @@
-@import './technology/variables';
 @import 'application';
+@import './technology/variables';
 @import './technology/diff';

--- a/app/javascript/styles/technology/diff.scss
+++ b/app/javascript/styles/technology/diff.scss
@@ -1,0 +1,75 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  border-bottom: 1px solid $ui-simple-bg-contrast;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+    a {
+      &:focus,
+      &:hover,
+      &:active {
+        background: darken($ui-secondary-color, 20%);
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+
+.activity-stream {
+  .entry {
+    .detailed-status.light,
+    .status.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+    .status.light {
+      .status__header {
+        .status__meta {
+          .status__relative-time {
+            color: $ui-simple-bg-contrast;
+            font-weight: bold;
+          }
+        }
+      }
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+    .detailed-status.light {
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+      .detailed-status__meta {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }  
+}

--- a/app/javascript/styles/technology/variables.scss
+++ b/app/javascript/styles/technology/variables.scss
@@ -1,4 +1,4 @@
-$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-simple-bg-contrast: $ui-primary-color;
 $ui-base-color: #0E2333;
 $ui-secondary-color: #E4E6DA;
 $ui-primary-color: #EBDC98;

--- a/app/javascript/styles/technology/variables.scss
+++ b/app/javascript/styles/technology/variables.scss
@@ -1,0 +1,9 @@
+$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-base-color: #0E2333;
+$ui-secondary-color: #E4E6DA;
+$ui-primary-color: #EBDC98;
+$ui-highlight-color: #398CCC;
+$error-value-color: #FF003C;
+$valid-value-color: #A8BF34;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: #EBDC98;

--- a/app/javascript/styles/woolly.scss
+++ b/app/javascript/styles/woolly.scss
@@ -1,9 +1,3 @@
-$ui-base-color: #392613;
-$ui-secondary-color: #7c818c;
-$ui-primary-color: #EBDC98;
-$ui-secondary-color: #EBDC98;
-$ui-highlight-color: #9494b8;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: $ui-highlight-color;
-
+@import './woolly/variables';
 @import 'application';
+@import './woolly/diff';

--- a/app/javascript/styles/woolly.scss
+++ b/app/javascript/styles/woolly.scss
@@ -1,3 +1,3 @@
-@import './woolly/variables';
 @import 'application';
+@import './woolly/variables';
 @import './woolly/diff';

--- a/app/javascript/styles/woolly/diff.scss
+++ b/app/javascript/styles/woolly/diff.scss
@@ -1,0 +1,75 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  border-bottom: 1px solid $ui-simple-bg-contrast;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+    a {
+      &:focus,
+      &:hover,
+      &:active {
+        background: darken($ui-secondary-color, 20%);
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+
+.activity-stream {
+  .entry {
+    .detailed-status.light,
+    .status.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+    .status.light {
+      .status__header {
+        .status__meta {
+          .status__relative-time {
+            color: $ui-simple-bg-contrast;
+            font-weight: bold;
+          }
+        }
+      }
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+    .detailed-status.light {
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+      .detailed-status__meta {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }  
+}

--- a/app/javascript/styles/woolly/variables.scss
+++ b/app/javascript/styles/woolly/variables.scss
@@ -1,0 +1,8 @@
+$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-base-color: #392613;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: #EBDC98;
+$ui-secondary-color: #EBDC98;
+$ui-highlight-color: #9494b8;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;

--- a/app/javascript/styles/woolly/variables.scss
+++ b/app/javascript/styles/woolly/variables.scss
@@ -1,4 +1,4 @@
-$ui-simple-bg-contrast: $ui-primary-color // Contrast color for elements too bright for $simple-background-color
+$ui-simple-bg-contrast: $ui-primary-color;
 $ui-base-color: #392613;
 $ui-secondary-color: #7c818c;
 $ui-primary-color: #EBDC98;


### PR DESCRIPTION
Hey Ash,

As requested many moons ago, I have re-factored the themes you merged in April. I have examined and followed the paradigm shown in the main project repo. This included:

* Made a folder for every theme
* Moved the variables for each theme into their respective folders inside of a variables.scss
* __Un-did__ all of the changes I made to the mastodon core scss theme
* Implemented those "un-did" changes into a diff.scss file for each theme inside of their theme folder
* Refactored the referenced theme file to import each theme file from the theme folders in sequential order: variables.scss first, application.scss, then the diff.scss changes.

I like it better this way. Each theme is actually isolated from the original project now :)