### PR TITLE
Refactor themes to adhere to new structure

### DIFF
--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,2 +1,2 @@
 VAGRANT=true
-LOCAL_DOMAIN=mastodon.dev
+LOCAL_DOMAIN=mastodon.local

--- a/.env.vagrant
+++ b/.env.vagrant
@@ -1,2 +1,2 @@
 VAGRANT=true
-LOCAL_DOMAIN=mastodon.local
+LOCAL_DOMAIN=mastodon.dev

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 sudo apt-add-repository 'deb https://dl.yarnpkg.com/debian/ stable main'
 
 # Add repo for NodeJS
-curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
+curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
 
 # Add firewall rule to redirect 80 to PORT and save
 sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port #{ENV["PORT"]}
@@ -85,6 +85,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb|
     vb.name = "mastodon"
     vb.customize ["modifyvm", :id, "--memory", "2048"]
+    # Increase the number of CPUs. Uncomment and adjust to
+    # increase performance
+    # vb.customize ["modifyvm", :id, "--cpus", "3"]
 
     # Disable VirtualBox DNS proxy to skip long-delay IPv6 resolutions.
     # https://github.com/mitchellh/vagrant/issues/1172
@@ -97,19 +100,22 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   end
 
-  config.vm.hostname = "mastodon.dev"
-
   # This uses the vagrant-hostsupdater plugin, and lets you
-  # access the development site at http://mastodon.dev.
+  # access the development site at http://mastodon.local.
+  # If you change it, also change it in .env.vagrant before provisioning
+  # the vagrant server to update the development build.
+  #
   # To install:
   #   $ vagrant plugin install vagrant-hostsupdater
+  config.vm.hostname = "mastodon.local"
+
   if defined?(VagrantPlugins::HostsUpdater)
     config.vm.network :private_network, ip: "192.168.42.42", nictype: "virtio"
     config.hostsupdater.remove_on_suspend = false
   end
 
   if config.vm.networks.any? { |type, options| type == :private_network }
-    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp']
+    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'actimeo=1']
   else
     config.vm.synced_folder ".", "/vagrant"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
 sudo apt-add-repository 'deb https://dl.yarnpkg.com/debian/ stable main'
 
 # Add repo for NodeJS
-curl -sL https://deb.nodesource.com/setup_8.x | sudo bash -
+curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
 
 # Add firewall rule to redirect 80 to PORT and save
 sudo iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-port #{ENV["PORT"]}
@@ -85,9 +85,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb|
     vb.name = "mastodon"
     vb.customize ["modifyvm", :id, "--memory", "2048"]
-    # Increase the number of CPUs. Uncomment and adjust to
-    # increase performance
-    # vb.customize ["modifyvm", :id, "--cpus", "3"]
 
     # Disable VirtualBox DNS proxy to skip long-delay IPv6 resolutions.
     # https://github.com/mitchellh/vagrant/issues/1172
@@ -100,22 +97,19 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   end
 
+  config.vm.hostname = "mastodon.dev"
+
   # This uses the vagrant-hostsupdater plugin, and lets you
-  # access the development site at http://mastodon.local.
-  # If you change it, also change it in .env.vagrant before provisioning
-  # the vagrant server to update the development build.
-  #
+  # access the development site at http://mastodon.dev.
   # To install:
   #   $ vagrant plugin install vagrant-hostsupdater
-  config.vm.hostname = "mastodon.local"
-
   if defined?(VagrantPlugins::HostsUpdater)
     config.vm.network :private_network, ip: "192.168.42.42", nictype: "virtio"
     config.hostsupdater.remove_on_suspend = false
   end
 
   if config.vm.networks.any? { |type, options| type == :private_network }
-    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp', 'actimeo=1']
+    config.vm.synced_folder ".", "/vagrant", type: "nfs", mount_options: ['rw', 'vers=3', 'tcp']
   else
     config.vm.synced_folder ".", "/vagrant"
   end

--- a/app/javascript/styles/arcdark.scss
+++ b/app/javascript/styles/arcdark.scss
@@ -1,9 +1,3 @@
-$ui-base-color: #383c4a;
-$ui-secondary-color: #7c818c;
-$ui-primary-color: $ui-secondary-color;
-$ui-secondary-color: #CC575D;
-$ui-highlight-color: #5294e2;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: $ui-highlight-color;
-
+@import './arcdark/variables';
 @import 'application';
+@import './arcdark/diff';

--- a/app/javascript/styles/arcdark/diff.scss
+++ b/app/javascript/styles/arcdark/diff.scss
@@ -1,0 +1,77 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  background: #ffffff;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+  a {
+    &:focus,
+    &:hover,
+    &:active {
+      background: darken($ui-secondary-color, 20%);
+      color: $ui-secondary-color;
+      outline: 0;
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast;
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+.activity-stream {
+  .entry {
+    background: $simple-background-color;
+
+    .detailed-status.light,
+    .status.light,
+    .more.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+  }
+
+  .status.light {
+    .status__header {
+      .status__meta {
+        .status__relative-time {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .detailed-status.light {
+    .detailed-status__display-name {
+      span {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }
+
+  .detailed-status__meta {
+    color: $ui-simple-bg-contrast;
+  }
+}

--- a/app/javascript/styles/arcdark/variables.scss
+++ b/app/javascript/styles/arcdark/variables.scss
@@ -1,0 +1,7 @@
+$ui-base-color: #383c4a;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: $ui-secondary-color;
+$ui-secondary-color: #CC575D;
+$ui-highlight-color: #5294e2;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;

--- a/app/javascript/styles/darkest.scss
+++ b/app/javascript/styles/darkest.scss
@@ -1,9 +1,3 @@
-$ui-base-color: #111111;
-$ui-secondary-color: #7c818c;
-$ui-primary-color: #EBDC98;
-$ui-secondary-color: #EBDC98;
-$ui-highlight-color: #CC575D;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: $ui-highlight-color;
-
+@import './darkest/variables';
 @import 'application';
+@import './darkest/diff';

--- a/app/javascript/styles/darkest/diff.scss
+++ b/app/javascript/styles/darkest/diff.scss
@@ -1,0 +1,82 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  background: #ffffff;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+  a {
+    &:focus,
+    &:hover,
+    &:active {
+      background: darken($ui-secondary-color, 20%);
+      color: $ui-secondary-color;
+      outline: 0;
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast;
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+.activity-stream {
+  .entry {
+    background: $simple-background-color;
+
+    .detailed-status.light,
+    .status.light,
+    .more.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .status.light {
+    .status__header {
+      .status__meta {
+        .status__relative-time {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .detailed-status.light {
+    .detailed-status__display-name {
+      span {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }
+
+  .detailed-status__meta {
+    color: $ui-simple-bg-contrast;
+  }
+}

--- a/app/javascript/styles/darkest/variables.scss
+++ b/app/javascript/styles/darkest/variables.scss
@@ -1,0 +1,7 @@
+$ui-base-color: #111111;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: #EBDC98;
+$ui-secondary-color: #EBDC98;
+$ui-highlight-color: #CC575D;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;

--- a/app/javascript/styles/mastodon/accounts.scss
+++ b/app/javascript/styles/mastodon/accounts.scss
@@ -575,7 +575,7 @@
 
 .activity-stream-tabs {
   background: $simple-background-color;
-  border-bottom: 1px solid $ui-simple-bg-contrast;
+  border-bottom: 1px solid $ui-secondary-color;
   position: relative;
   z-index: 2;
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -506,7 +506,7 @@
 
   .compose-form__buttons-wrapper {
     padding: 10px;
-    background: $ui-base-color;
+    background: darken($simple-background-color, 8%);
     border-radius: 0 0 4px 4px;
     display: flex;
     justify-content: space-between;
@@ -545,7 +545,7 @@
         font-family: 'mastodon-font-sans-serif', sans-serif;
         font-size: 14px;
         font-weight: 600;
-        color: lighten($ui-primary-color, 33%);
+        color: lighten($ui-base-color, 12%);
 
         &.character-counter--over {
           color: $warning-red;
@@ -1648,7 +1648,7 @@ a.account__display-name {
     &:focus,
     &:hover,
     &:active {
-      background: darken($ui-secondary-color, 20%);
+      background: $ui-highlight-color;
       color: $ui-secondary-color;
       outline: 0;
     }
@@ -4888,7 +4888,7 @@ a.status-card {
 
   h4 {
     text-transform: uppercase;
-    color: $ui-simple-bg-contrast;
+    color: $ui-primary-color;
     font-size: 13px;
     font-weight: 500;
     margin-bottom: 10px;

--- a/app/javascript/styles/mastodon/emoji_picker.scss
+++ b/app/javascript/styles/mastodon/emoji_picker.scss
@@ -36,7 +36,7 @@
   display: flex;
   justify-content: space-between;
   padding: 0 6px;
-  color: $ui-simple-bg-contrast;
+  color: $ui-primary-color;
   line-height: 0;
 }
 

--- a/app/javascript/styles/mastodon/stream_entries.scss
+++ b/app/javascript/styles/mastodon/stream_entries.scss
@@ -8,7 +8,7 @@
     .detailed-status.light,
     .status.light,
     .more.light {
-      border-bottom: 1px solid $ui-simple-bg-contrast;
+      border-bottom: 1px solid $ui-secondary-color;
       animation: none;
     }
 
@@ -84,8 +84,7 @@
         font-size: 14px;
 
         .status__relative-time {
-          color: $ui-simple-bg-contrast;
-          font-weight: bold;
+          color: $ui-primary-color;
         }
       }
     }
@@ -135,7 +134,7 @@
 
       span {
         font-size: 14px;
-        color: $ui-simple-bg-contrast;
+        color: $ui-primary-color;
       }
     }
 
@@ -192,7 +191,7 @@
 
         span {
           font-size: 14px;
-          color: $ui-simple-bg-contrast;
+          color: $ui-primary-color;
         }
       }
     }
@@ -226,7 +225,7 @@
 
     .detailed-status__meta {
       margin-top: 15px;
-      color: $ui-simple-bg-contrast;
+      color: $ui-primary-color;
       font-size: 14px;
       line-height: 18px;
 

--- a/app/javascript/styles/mastodon/variables.scss
+++ b/app/javascript/styles/mastodon/variables.scss
@@ -26,7 +26,6 @@ $ui-base-lighter-color: lighten($ui-base-color, 26%) !default; // Lighter darkes
 $ui-primary-color: $classic-primary-color !default;            // Lighter
 $ui-secondary-color: $classic-secondary-color !default;        // Lightest
 $ui-highlight-color: $classic-highlight-color !default;        // Vibrant
-$ui-simple-bg-contrast: $ui-primary-color !default;            // Contrast color for elements too bright for $simple-background-color
 
 // Variables for texts
 $primary-text-color: $white !default;

--- a/app/javascript/styles/solarizeddark.scss
+++ b/app/javascript/styles/solarizeddark.scss
@@ -1,14 +1,4 @@
 // Turn your face to the sun and the shadows will fall behind you.
-
-$primary-text-color: lighten(#93A1A1, 25%);
-
-$ui-base-color: #002B36;
-$ui-base-lighter-color: lighten($ui-base-color, 30%);
-$ui-primary-color: #93A1A1;
-$ui-secondary-color: #2AA198;
-$ui-highlight-color: #6C71C4;
-$ui-simple-bg-contrast: #6C71C4;
-
-$gold-star: #CB4B16;
-
+@import './solarizeddark/variables';
 @import 'application';
+@import './solarizeddark/diff';

--- a/app/javascript/styles/solarizeddark/diff.scss
+++ b/app/javascript/styles/solarizeddark/diff.scss
@@ -1,0 +1,77 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  background: #ffffff;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+  a {
+    &:focus,
+    &:hover,
+    &:active {
+      background: darken($ui-secondary-color, 20%);
+      color: $ui-secondary-color;
+      outline: 0;
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast;
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+.activity-stream {
+  .entry {
+    background: $simple-background-color;
+
+    .detailed-status.light,
+    .status.light,
+    .more.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+  }
+
+  .status.light {
+    .status__header {
+      .status__meta {
+        .status__relative-time {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .detailed-status.light {
+    .detailed-status__display-name {
+      span {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }
+
+  .detailed-status__meta {
+    color: $ui-simple-bg-contrast;
+  }
+}

--- a/app/javascript/styles/solarizeddark/variables.scss
+++ b/app/javascript/styles/solarizeddark/variables.scss
@@ -1,0 +1,10 @@
+$primary-text-color: lighten(#93A1A1, 25%);
+
+$ui-base-color: #002B36;
+$ui-base-lighter-color: lighten($ui-base-color, 30%);
+$ui-primary-color: #93A1A1;
+$ui-secondary-color: #2AA198;
+$ui-highlight-color: #6C71C4;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+
+$gold-star: #CB4B16;

--- a/app/javascript/styles/technology.scss
+++ b/app/javascript/styles/technology.scss
@@ -1,10 +1,3 @@
-$ui-base-color: #0E2333;
-$ui-secondary-color: #E4E6DA;
-$ui-primary-color: #EBDC98;
-$ui-highlight-color: #398CCC;
-$error-value-color: #FF003C;
-$valid-value-color: #A8BF34;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: #EBDC98;
-
+@import './technology/variables';
 @import 'application';
+@import './technology/diff';

--- a/app/javascript/styles/technology/diff.scss
+++ b/app/javascript/styles/technology/diff.scss
@@ -1,0 +1,82 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  background: #ffffff;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+  a {
+    &:focus,
+    &:hover,
+    &:active {
+      background: darken($ui-secondary-color, 20%);
+      color: $ui-secondary-color;
+      outline: 0;
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast;
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+.activity-stream {
+  .entry {
+    background: $simple-background-color;
+
+    .detailed-status.light,
+    .status.light,
+    .more.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .status.light {
+    .status__header {
+      .status__meta {
+        .status__relative-time {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .detailed-status.light {
+    .detailed-status__display-name {
+      span {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }
+
+  .detailed-status__meta {
+    color: $ui-simple-bg-contrast;
+  }
+}

--- a/app/javascript/styles/technology/variables.scss
+++ b/app/javascript/styles/technology/variables.scss
@@ -1,0 +1,8 @@
+$ui-base-color: #0E2333;
+$ui-secondary-color: #E4E6DA;
+$ui-primary-color: #EBDC98;
+$ui-highlight-color: #398CCC;
+$error-value-color: #FF003C;
+$valid-value-color: #A8BF34;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: #EBDC98;

--- a/app/javascript/styles/woolly.scss
+++ b/app/javascript/styles/woolly.scss
@@ -1,9 +1,3 @@
-$ui-base-color: #392613;
-$ui-secondary-color: #7c818c;
-$ui-primary-color: #EBDC98;
-$ui-secondary-color: #EBDC98;
-$ui-highlight-color: #9494b8;
-$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
-$gold-star: $ui-highlight-color;
-
+@import './woolly/variables';
 @import 'application';
+@import './woolly/diff';

--- a/app/javascript/styles/woolly/diff.scss
+++ b/app/javascript/styles/woolly/diff.scss
@@ -1,0 +1,82 @@
+// mastodon/accounts.scss
+.activity-stream-tabs {
+  background: #ffffff;
+}
+
+// mastodon/components.scss
+.compose-form {
+  .compose-form__buttons-wrapper {
+    background: $ui-base-color;
+
+    .character-counter__wrapper {
+      .character-counter {
+        color: lighten($ui-primary-color, 33%);
+      }
+    }
+  }
+}
+
+.dropdown-menu__item {
+  a {
+    &:focus,
+    &:hover,
+    &:active {
+      background: darken($ui-secondary-color, 20%);
+      color: $ui-secondary-color;
+      outline: 0;
+    }
+  }
+}
+
+.search-popout {
+  color: $ui-simple-bg-contrast;
+  h4 {
+    color: $ui-simple-bg-contrast;
+  }
+}
+
+// mastodon/emoji_picker.scss
+
+.emoji-mart-anchors {
+  color: $ui-simple-bg-contrast;
+}
+
+// mastodon/stream_entries.scss
+.activity-stream {
+  .entry {
+    background: $simple-background-color;
+
+    .detailed-status.light,
+    .status.light,
+    .more.light {
+      border-bottom: 1px solid $ui-simple-bg-contrast;
+      .display-name {
+        span {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .status.light {
+    .status__header {
+      .status__meta {
+        .status__relative-time {
+          color: $ui-simple-bg-contrast;
+        }
+      }
+    }
+  }
+
+  .detailed-status.light {
+    .detailed-status__display-name {
+      span {
+        color: $ui-simple-bg-contrast;
+      }
+    }
+  }
+
+  .detailed-status__meta {
+    color: $ui-simple-bg-contrast;
+  }
+}

--- a/app/javascript/styles/woolly/variables.scss
+++ b/app/javascript/styles/woolly/variables.scss
@@ -1,0 +1,7 @@
+$ui-base-color: #392613;
+$ui-secondary-color: #7c818c;
+$ui-primary-color: #EBDC98;
+$ui-secondary-color: #EBDC98;
+$ui-highlight-color: #9494b8;
+$ui-simple-bg-contrast: lighten($ui-base-color, 30%);
+$gold-star: $ui-highlight-color;


### PR DESCRIPTION
## Heyo!

I'm sorry this took me forever! The themes refactor is now completed :+1: 
**Note: be sure to merge this prior to merging #10 **
Each theme has been given a nested folder to store two important scss files: variables.scss & diff.scss

**variables.scss** stores variables to override default theme as well as add new variables to be used in...
**diff.scss** stores the CSS selector overrides and requires variables to be imported first.

_A general idea of how these themes work_

/app/javascript/styles/example.scss -> (main theme export)
```scss
@import './example/variables';
@import 'application';
@import './example/diff';
```
/app/javascript/styles/example/variables.scss -> (variables override)
```scss
$ui-primary-color: purple;
```
/app/javascript/styles/application.scss -> (default styles that get overridden - don't touch, just import before diff)

/app/javascript/styles/example/diff.scss -> (styles override)
```scssoverrided
.compose-form {
  color: $ui-primary-color;  // Now purple
}
```