### PR TITLE
fix css styles in custom themes

### DIFF
--- a/app/javascript/styles/arcdark/diff.scss
+++ b/app/javascript/styles/arcdark/diff.scss
@@ -1,8 +1,3 @@
-// mastodon/accounts.scss
-.activity-stream-tabs {
-  background: #ffffff;
-}
-
 // mastodon/components.scss
 .compose-form {
   .compose-form__buttons-wrapper {
@@ -44,8 +39,6 @@
 // mastodon/stream_entries.scss
 .activity-stream {
   .entry {
-    background: $simple-background-color;
-
     .detailed-status.light,
     .status.light,
     .more.light {
@@ -61,6 +54,10 @@
         }
       }
     }
+  }
+
+  .status__content__spoiler-link {
+    color:$ui-base-color;
   }
 
   .detailed-status.light {

--- a/app/javascript/styles/darkest/diff.scss
+++ b/app/javascript/styles/darkest/diff.scss
@@ -1,8 +1,3 @@
-// mastodon/accounts.scss
-.activity-stream-tabs {
-  background: #ffffff;
-}
-
 // mastodon/components.scss
 .compose-form {
   .compose-form__buttons-wrapper {
@@ -44,8 +39,6 @@
 // mastodon/stream_entries.scss
 .activity-stream {
   .entry {
-    background: $simple-background-color;
-
     .detailed-status.light,
     .status.light,
     .more.light {

--- a/app/javascript/styles/solarizeddark/diff.scss
+++ b/app/javascript/styles/solarizeddark/diff.scss
@@ -1,8 +1,3 @@
-// mastodon/accounts.scss
-.activity-stream-tabs {
-  background: #ffffff;
-}
-
 // mastodon/components.scss
 .compose-form {
   .compose-form__buttons-wrapper {
@@ -44,12 +39,18 @@
 // mastodon/stream_entries.scss
 .activity-stream {
   .entry {
-    background: $simple-background-color;
-
     .detailed-status.light,
     .status.light,
     .more.light {
       border-bottom: 1px solid $ui-simple-bg-contrast;
+    }
+  }
+
+  .status__content__spoiler-link {
+    background-color: $ui-highlight-color;
+    color:$ui-base-color;
+    &:hover {
+      background-color: lighten($ui-highlight-color, 10%);
     }
   }
 

--- a/app/javascript/styles/technology/diff.scss
+++ b/app/javascript/styles/technology/diff.scss
@@ -1,8 +1,3 @@
-// mastodon/accounts.scss
-.activity-stream-tabs {
-  background: #ffffff;
-}
-
 // mastodon/components.scss
 .compose-form {
   .compose-form__buttons-wrapper {

--- a/app/javascript/styles/woolly/diff.scss
+++ b/app/javascript/styles/woolly/diff.scss
@@ -1,8 +1,3 @@
-// mastodon/accounts.scss
-.activity-stream-tabs {
-  background: #ffffff;
-}
-
 // mastodon/components.scss
 .compose-form {
   .compose-form__buttons-wrapper {
@@ -44,8 +39,6 @@
 // mastodon/stream_entries.scss
 .activity-stream {
   .entry {
-    background: $simple-background-color;
-
     .detailed-status.light,
     .status.light,
     .more.light {


### PR DESCRIPTION
Ref: 3f210372a
This pull request is to fix styling issues with the public activity stream where the white background drowns out the text in my contributed themes. It's basically the same thing you did to fix yours. I also tweaked the CW colors as they looked clashy in SolarizedDark and ArcDark.

More themes to come in a later pull request!