### PR TITLE
Adds Puma Worker Killer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+# Mastodon appears to grow in memory use for over a week, linearly.
+# Switching to jemalloc improved the rat eof growth but didn't stop it.
+# So this restarts Puma workers when their memory use gets too high.
+# Sorry.
+gem 'puma_worker_killer'
+
 source 'https://rubygems.org'
 ruby '>= 2.3.0', '< 2.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -413,6 +413,9 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.12.0)
+    puma_worker_killer (0.1.0)
+      get_process_mem (~> 0.2)
+      puma (>= 2.7, < 4)
     pundit (1.1.0)
       activesupport (>= 3.0.0)
     rack (2.0.5)
@@ -722,6 +725,7 @@ DEPENDENCIES
   pry-byebug (~> 3.6)
   pry-rails (~> 0.3)
   puma (~> 3.12)
+  puma_worker_killer
   pundit (~> 1.1)
   rack-attack (~> 5.2)
   rack-cors (~> 1.0)
@@ -765,4 +769,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -16,4 +16,10 @@ on_worker_boot do
   ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
 end
 
+# See note in Gemfile.
+before_fork do
+  require 'puma_worker_killer'
+  PumaWorkerKiller.start
+end
+
 plugin :tmp_restart


### PR DESCRIPTION
Okayyyyyy so here's what's going on. Mastodon memory use goes up until workers get restarted. I was doing this manually, but it looks like Docker's out-of-memory warnings do this anyway if memory pressure gets too great. I switched to jemalloc (see #8) but it only delays the memory growth, which looks like this:

![DigitalOcean screenshot of memory use over the past week](https://user-images.githubusercontent.com/498212/47259633-06347580-d47a-11e8-9920-eb43adbbdd79.png)

This is frustrating. I don't want to add this but I don't want to rely on host VM memory warnings to keep mastodon.technology running. [`puma_worker_killer`](https://github.com/schneems/puma_worker_killer) is a tool that checks memory use periodically and kills if it's too high (default is over a gig, we'll see!

This shouldn't impact users, since Puma will restart workers automatically after they're killed (and they'll start at a low memory footprint again).

The configuration checks every 5 seconds and kills if a worker (which I have two of) exceeds 1GB of ram. There is another configuration to use rolling restarts at a set frequency. We'll see if Docker and PWK work together (it's popularly used on Heroku).