### PR TITLE
Adds Rake tasks examples for admins

### DIFF
--- a/lib/tasks/custom.rake
+++ b/lib/tasks/custom.rake
@@ -5,12 +5,14 @@ namespace :custom do
     puts "The database has #{Account.count} users."
   end
 
+  task silence_logs: :environment do
+    ActiveRecord::Base.logger = Logger.new('/dev/null')
+  end
+
   desc 'Lookup by IP'
-  task :find_by_ip, [:ip] => [:environment] do |_task, args|
+  task :find_by_ip, [:ip] => [:environment, :silence_logs] do |_task, args|
     ip = args[:ip]
     raise 'Specify an IP address in Rake invocation' if ip.nil?
-
-    ActiveRecord::Base.logger = Logger.new('/dev/null')
 
     # You can do this manually this way:
     # ids = User.where(last_sign_in_ip: ip).pluck(:id)
@@ -21,5 +23,23 @@ namespace :custom do
     Account.joins(:user).where(users: {last_sign_in_ip: ip}).find_each do |account|
       puts account.username
     end
+  end
+
+  desc 'Creates report from one account to another'
+  task :report_from_to, [:from_username, :reported_username] => [:environment, :silence_logs] do |_task, args|
+    from_username = args[:from_username]
+    reported_username = args[:reported_username]
+    raise 'Need both from and reported fields' if from_username.nil? || reported_username.nil?
+
+    from_account = Account.find_by(username: from_username)
+    reported_account = Account.find_by(username: reported_username)
+    raise "Cound not find reporting account '#{from_username}' in database." if from_account.nil?
+    raise "Cound not find reported account '#{reported_username}' in database." if reported_account.nil?
+
+    ReportService.new.call(
+      from_account,
+      reported_account,
+      comment: 'This report was opened by running a Rake task.'
+    )
   end
 end

--- a/lib/tasks/custom.rake
+++ b/lib/tasks/custom.rake
@@ -4,4 +4,22 @@ namespace :custom do
     puts 'This is an example task.'
     puts "The database has #{Account.count} users."
   end
+
+  desc 'Lookup by IP'
+  task :find_by_ip, [:ip] => [:environment] do |_task, args|
+    ip = args[:ip]
+    raise 'Specify an IP address in Rake invocation' if ip.nil?
+
+    ActiveRecord::Base.logger = Logger.new('/dev/null')
+
+    # You can do this manually this way:
+    # ids = User.where(last_sign_in_ip: ip).pluck(:id)
+    # accounts = Account.where(id: ids).pluck(:username)
+
+    # Or we can be fancy and user ActiveRecord
+    # See docs: https://guides.rubyonrails.org/active_record_querying.html
+    Account.joins(:user).where(users: {last_sign_in_ip: ip}).find_each do |account|
+      puts account.username
+    end
+  end
 end

--- a/lib/tasks/custom.rake
+++ b/lib/tasks/custom.rake
@@ -1,0 +1,7 @@
+namespace :custom do
+  desc 'Custom task'
+  task example: :environment do
+    puts 'This is an example task.'
+    puts "The database has #{Account.count} users."
+  end
+end


### PR DESCRIPTION
This PR creates a few Rake tasks, designed to be templates for Mastodon admins to automate administrative tasks while we wait for an admin API in a future Mastodon release. 

**Why?** Because running things is hard and computers are good at looking for things. For example, if a user is repeatedly opening new accounts from specific IP, posting a specific link, admins should feel empowered to write code to look for patterns in code, then automate that with a cron job. 

This PR includes two tasks of note:

- A task to look up all usernames how most recently signed in from a certain IP address.
- A task to open a report (from a specific username, reporting a specific username).

While these two tasks could already be combined together in a bash script, I'm hoping that these can be _instructive_, rather than used as-is. ActiveRecord (docs linked to in the code) allows for really high-level queries without messing around with SQL. **The advantage of using ActiveRecord is that we execute our queries in the context of Mastodon's application code**; for example, the second task demonstrates how to use the `ReportService` to perform an action. Almost all actions performed through the Mastodon UI are executed by _services_, and by calling those existing services, we effectively behave _as if_  we were using the Mastodon UI. In the example of opening a report, moderators are notified by email of the report.

<img width="869" alt="Screen Shot 2019-03-30 at 12 02 49 PM" src="https://user-images.githubusercontent.com/498212/55278604-de78f180-52e4-11e9-9d0b-8825bc31944e.png">

**Why not use the Mastodon CLI?** This is a really good question. The CLI is powerful, but it's really designed for specific purposes. We need the flexibility of a high-level language to perform bespoke queries against the database, so I felt adding a new set of Rake tasks would circumvent the CLI abstraction, which would just introduce friction. And the simple fact is, I'm more comfortable in Ruby than I am writing bash scripts. Someone else might take a different approach.

**How do I run these tasks?** You need to run these tasks in the same environment as your server (so: maybe `bundle exec rake custom:...` or maybe `docker exec -i -t mastodon_web_1 rake custom:...`). Rake task arguments are weird: depending on your shell, you'll need to only separate them by commas (and not spaces). So for example:

```sh
bundle exec rake custom:report_from_to["reportingusername","reportedusername"]
```

They're positional, but in the `.rake` files, they're named. 

**So what next?** Now, we wait. The spammer [claims to have stopped](https://mastodon.technology/@ashfurrow/101840148534473804), and while I don't believe them, I do believe that these tools will be valuable as the Fediverse grows.