### PR TITLE
Fix logo-button alignment issue

### DIFF
--- a/app/javascript/styles/mastodon/statuses.scss
+++ b/app/javascript/styles/mastodon/statuses.scss
@@ -92,6 +92,8 @@
   hyphens: auto;
   padding: 0 15px;
   border: 0;
+  display: inline-flex;
+  align-items: center;
 
   svg {
     width: 20px;


### PR DESCRIPTION
Today I went to some user's toot, and I saw the "Follow" button not aligned properly. This fixed it.

![image](https://user-images.githubusercontent.com/25210925/120579593-668b4200-c3ed-11eb-9249-450094f58029.png) changes to ![image](https://user-images.githubusercontent.com/25210925/120579663-8884c480-c3ed-11eb-8850-40bd40ff3f4a.png).

**How to reproduce:**
- [Example link](https://mastodon.technology/@sarrietav/106327867914463363)
- Brave Latest (v.1.25.68)
- Firefox Developer Edition Latest (v89.0b10)
